### PR TITLE
Fixes network connectivity monitor crash

### DIFF
--- a/Sources/ExyteChat/Extensions/NetworkMonitor.swift
+++ b/Sources/ExyteChat/Extensions/NetworkMonitor.swift
@@ -12,15 +12,15 @@ public final class NetworkConnectivityMonitor: ObservableObject {
     private let networkMonitor = NWPathMonitor()
     private let workerQueue = DispatchQueue(label: "com.sonata.network-conectivity-monitor")
 
-    @Published public private(set) var isConnected = false
+    @Published public private(set) var isNetworkAvailable: Bool? = nil
 
     public init() {
         networkMonitor.pathUpdateHandler = { [weak self] path in
             let newStatus = path.status == .satisfied
             Task { @MainActor in
                 guard let self else { return }
-                if self.isConnected != newStatus {
-                    self.isConnected = newStatus
+                if self.isNetworkAvailable != newStatus {
+                    self.isNetworkAvailable = newStatus
                 }
             }
         }

--- a/Sources/ExyteChat/Extensions/NetworkMonitor.swift
+++ b/Sources/ExyteChat/Extensions/NetworkMonitor.swift
@@ -8,18 +8,18 @@
 import Foundation
 import Network
 
-public final class NetworkMonitor: ObservableObject {
+public final class NetworkConnectivityMonitor: ObservableObject {
     private let networkMonitor = NWPathMonitor()
-    private let workerQueue = DispatchQueue(label: "com.sonata.network.monitor")
-    
-    @Published public private(set) var isConnected: Bool = false
+    private let workerQueue = DispatchQueue(label: "com.sonata.network-conectivity-monitor")
+
+    @Published public private(set) var isConnected = false
 
     public init() {
         networkMonitor.pathUpdateHandler = { [weak self] path in
-            guard let self else { return }
             let newStatus = path.status == .satisfied
-            if self.isConnected != newStatus {
-                DispatchQueue.main.async {
+            Task { @MainActor in
+                guard let self else { return }
+                if self.isConnected != newStatus {
                     self.isConnected = newStatus
                 }
             }


### PR DESCRIPTION
Addresses a crash by isolating network connectivity state updates to the MainActor. This change prevents race conditions and ensures thread-safe delivery of connectivity status to observers.

Refactors the network monitoring class and renames its connectivity state property to improve clarity and better represent the initial unknown state.